### PR TITLE
Revert "Fix undefined behaviour and ordering of Pivots"

### DIFF
--- a/e06-bettersorting/src/test/DoubleDistributedMedianPivotTest.java
+++ b/e06-bettersorting/src/test/DoubleDistributedMedianPivotTest.java
@@ -11,27 +11,27 @@ public class DoubleDistributedMedianPivotTest {
         // -1- -2- 4
         int[] numbers = new int[]{4, 9, 1, 10, 2};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(3);
-        assertDoubleMedians(2, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(2, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // -3- -4- 15
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(3);
-        assertDoubleMedians(0, 10, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(10, 0, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 1 -2- 4 -13- 17
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(5);
-        assertDoubleMedians(4, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(4, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // -4- 10 -13- 55
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(4);
-        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 1 2 3 -4- 9 10 11 -13- 15 17 26 55
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(numbers.length);
-        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length));
     }
 
 
@@ -40,17 +40,17 @@ public class DoubleDistributedMedianPivotTest {
         // 19 20 21 -22- 23 24 25 -26- 27 28 29 30
         int[] numbers = new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(numbers.length);
-        assertDoubleMedians(4, 8, dualPivotFinder.findPivot(numbers, 0, 11));
+        assertDoubleMedians(8, 4, dualPivotFinder.findPivot(numbers, 0, 11));
 
         // 22 -24- 26 -28- 30
         numbers = new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(5);
-        assertDoubleMedians(2, 6, dualPivotFinder.findPivot(numbers, 0, 11));
+        assertDoubleMedians(6, 2, dualPivotFinder.findPivot(numbers, 0, 11));
 
         // 0 -6- 12 -16- 18
         numbers = new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(5);
-        assertDoubleMedians(14, 18, dualPivotFinder.findPivot(numbers, 12, numbers.length));
+        assertDoubleMedians(18, 14, dualPivotFinder.findPivot(numbers, 12, numbers.length));
     }
 
     @Test
@@ -58,7 +58,7 @@ public class DoubleDistributedMedianPivotTest {
         // 5 -6- 6 -55- 55
         int[] numbers = new int[]{5, 6, 5, 6, 55, 6, 5, 6, 55, 6, 5, 6, 5};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(numbers.length);
-        assertDoubleMedians(4, 5, dualPivotFinder.findPivot(numbers, 4, 8));
+        assertDoubleMedians(5, 4, dualPivotFinder.findPivot(numbers, 4, 8));
 
         // 5 5 -5- 5 5 -5- 55 55
         numbers = new int[]{5, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 5};
@@ -73,7 +73,6 @@ public class DoubleDistributedMedianPivotTest {
 
     private void assertDoubleMedians(int firstPivot, int secondPivot, int[] actualPivots) {
         assertEquals(2, actualPivots.length);
-        Arrays.sort(actualPivots);
         assertEquals(firstPivot, actualPivots[0]);
         assertEquals(secondPivot, actualPivots[1]);
     }

--- a/e06-bettersorting/src/test/DoubleDistributedMedianPivotTest.java
+++ b/e06-bettersorting/src/test/DoubleDistributedMedianPivotTest.java
@@ -11,27 +11,27 @@ public class DoubleDistributedMedianPivotTest {
         // -1- -2- 4
         int[] numbers = new int[]{4, 9, 1, 10, 2};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(3);
-        assertDoubleMedians(2, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(2, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // -3- -4- 15
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(3);
-        assertDoubleMedians(10, 0, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(10, 0, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 1 -2- 4 -13- 17
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(5);
-        assertDoubleMedians(4, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(4, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // -4- 10 -13- 55
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(4);
-        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 1 2 3 -4- 9 10 11 -13- 15 17 26 55
         numbers = new int[]{4, 9, 1, 10, 2, 15, 13, 26, 17, 55, 3, 11};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(numbers.length);
-        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
     }
 
 
@@ -50,7 +50,7 @@ public class DoubleDistributedMedianPivotTest {
         // 0 -6- 12 -16- 18
         numbers = new int[]{30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 12, 9, 6, 3, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotDistributed(5);
-        assertDoubleMedians(18, 14, dualPivotFinder.findPivot(numbers, 12, numbers.length));
+        assertDoubleMedians(18, 14, dualPivotFinder.findPivot(numbers, 12, numbers.length - 1));
     }
 
     @Test

--- a/e06-bettersorting/src/test/DoubleMedianPivotTest.java
+++ b/e06-bettersorting/src/test/DoubleMedianPivotTest.java
@@ -12,32 +12,32 @@ public class DoubleMedianPivotTest {
         // 1 -2- 4 -9- 10
         int[] numbers = new int[]{4, 9, 1, 10, 2};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(5);
-        assertDoubleMedians(1, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(4, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 1 2 3 -4- 5 6 9 -10- 23 35 99
         numbers = new int[]{4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 1 -2- 4 -9- 10
         numbers = new int[]{4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(5);
-        assertDoubleMedians(1, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(4, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 8 10 -24- 29 38 -42- 57 75 77
         numbers = new int[]{8, 42, 10, 75, 29, 77, 38, 57, 24};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(1, 8, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(8, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 8 10 -24- 29 38 -57- 75 76 77
         numbers = new int[]{24, 8, 76, 10, 75, 29, 77, 38, 57};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 8, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 8, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 8 10 -24- 29 38 40 -42- 57 75 77
         numbers = new int[]{24, 8, 42, 10, 75, 29, 77, 38, 57, 40};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 2, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 2, dualPivotFinder.findPivot(numbers, 0, numbers.length));
     }
 
     @Test
@@ -46,27 +46,27 @@ public class DoubleMedianPivotTest {
         int[] numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         assertEquals(31, numbers.length);
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(27, 28, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(27, 28, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 1 -4- 13 -15- 26 30
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(6);
-        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 2, numbers.length - 1));
+        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 2, numbers.length));
 
         // 1 -2- 12 13 -15- 26 29
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(7);
-        assertDoubleMedians(4, 8, dualPivotFinder.findPivot(numbers, 4, numbers.length - 1));
+        assertDoubleMedians(8, 4, dualPivotFinder.findPivot(numbers, 4, numbers.length));
 
         // 2 10 -12- 13 17 -22- 26 29
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(8);
-        assertDoubleMedians(10, 13, dualPivotFinder.findPivot(numbers, 6, numbers.length - 1));
+        assertDoubleMedians(10, 13, dualPivotFinder.findPivot(numbers, 6, numbers.length));
 
         // 1 2 -4- 11 13 15 -21- 26 29 30
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(1, 3, dualPivotFinder.findPivot(numbers, 0, 9));
+        assertDoubleMedians(3, 1, dualPivotFinder.findPivot(numbers, 0, 9));
 
         // -11- -21- 30
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
@@ -84,17 +84,17 @@ public class DoubleMedianPivotTest {
         // 5 5 5 -5- 5 6 6 6 -6- 6 6 55 55
         numbers = new int[]{5, 6, 5, 6, 55, 6, 5, 6, 55, 6, 5, 6, 5};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 2 4 8 8 8 -12- 14 26 26 28 30 -30- 30 30 34 36 36
         numbers = new int[]{2, 4, 8, 8, 8, 12, 14, 26, 26, 28, 30, 30, 30, 30, 34, 36, 36};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(5, 10, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(5, 10, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 5 6 7 -44- 44 44 44 -44- 44 44 44
         numbers = new int[]{5, 6, 7, 44, 44, 44, 44, 44, 44, 44, 44};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length));
     }
 
     @Test
@@ -102,22 +102,22 @@ public class DoubleMedianPivotTest {
         // 2 2 -2- 2 2 2 -2- 2 2 2
         int[] numbers = new int[]{2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 2 4 10 -10- 10 10 11 12 -12- 12 14 15 16
         numbers = new int[]{16, 15, 14, 12, 12, 12, 11, 10, 10, 10, 10, 4, 2};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(3, 7, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(7, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 2 4 10 -10- 10 10 12 -12- 12 14 15 16
         numbers = new int[]{16, 15, 14, 12, 12, 12, 10, 10, 10, 10, 4, 2};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(3, 6, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(6, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 10 10 -10- 10 10 -10- 15 20
         numbers = new int[]{10, 10, 10, 15, 10, 20, 10, 10};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
     }
 
     /**
@@ -133,17 +133,16 @@ public class DoubleMedianPivotTest {
         // 5 5 5 5 5 -5- 6 6 6 6 6 -6- 6 6 55 55 55
         int[] numbers = new int[]{5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
 
         // 5 6 7 -44- 44 44 44 -44- 44 44 44
         numbers = new int[]{44, 44, 44, 5, 6, 44, 44, 7, 44, 44, 44};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
     }
 
     private void assertDoubleMedians(int firstPivot, int secondPivot, int[] actualPivots) {
         assertEquals(2, actualPivots.length);
-        Arrays.sort(actualPivots);
         assertEquals(firstPivot, actualPivots[0]);
         assertEquals(secondPivot, actualPivots[1]);
     }

--- a/e06-bettersorting/src/test/DoubleMedianPivotTest.java
+++ b/e06-bettersorting/src/test/DoubleMedianPivotTest.java
@@ -12,32 +12,32 @@ public class DoubleMedianPivotTest {
         // 1 -2- 4 -9- 10
         int[] numbers = new int[]{4, 9, 1, 10, 2};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(5);
-        assertDoubleMedians(4, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(4, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 1 2 3 -4- 5 6 9 -10- 23 35 99
         numbers = new int[]{4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 1 -2- 4 -9- 10
         numbers = new int[]{4, 9, 1, 10, 2, 5, 99, 23, 3, 35, 6};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(5);
-        assertDoubleMedians(4, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(4, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 8 10 -24- 29 38 -42- 57 75 77
         numbers = new int[]{8, 42, 10, 75, 29, 77, 38, 57, 24};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(8, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(8, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 8 10 -24- 29 38 -57- 75 76 77
         numbers = new int[]{24, 8, 76, 10, 75, 29, 77, 38, 57};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 8, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 8, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 8 10 -24- 29 38 40 -42- 57 75 77
         numbers = new int[]{24, 8, 42, 10, 75, 29, 77, 38, 57, 40};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 2, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 2, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
     }
 
     @Test
@@ -46,22 +46,22 @@ public class DoubleMedianPivotTest {
         int[] numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         assertEquals(31, numbers.length);
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(27, 28, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(27, 28, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 1 -4- 13 -15- 26 30
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(6);
-        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 2, numbers.length));
+        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 2, numbers.length - 1));
 
         // 1 -2- 12 13 -15- 26 29
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(7);
-        assertDoubleMedians(8, 4, dualPivotFinder.findPivot(numbers, 4, numbers.length));
+        assertDoubleMedians(8, 4, dualPivotFinder.findPivot(numbers, 4, numbers.length - 1));
 
         // 2 10 -12- 13 17 -22- 26 29
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(8);
-        assertDoubleMedians(10, 13, dualPivotFinder.findPivot(numbers, 6, numbers.length));
+        assertDoubleMedians(10, 13, dualPivotFinder.findPivot(numbers, 6, numbers.length - 1));
 
         // 1 2 -4- 11 13 15 -21- 26 29 30
         numbers = new int[]{11, 21, 30, 4, 15, 1, 26, 13, 2, 29, 12, 10, 17, 22, 25, 24, 18, 28, 6, 14, 16, 19, 3, 5, 7, 27, 8, 9, 20, 23, 0};
@@ -84,17 +84,17 @@ public class DoubleMedianPivotTest {
         // 5 5 5 -5- 5 6 6 6 -6- 6 6 55 55
         numbers = new int[]{5, 6, 5, 6, 55, 6, 5, 6, 55, 6, 5, 6, 5};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 2 4 8 8 8 -12- 14 26 26 28 30 -30- 30 30 34 36 36
         numbers = new int[]{2, 4, 8, 8, 8, 12, 14, 26, 26, 28, 30, 30, 30, 30, 34, 36, 36};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(5, 10, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(5, 10, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 5 6 7 -44- 44 44 44 -44- 44 44 44
         numbers = new int[]{5, 6, 7, 44, 44, 44, 44, 44, 44, 44, 44};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(3, 4, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
     }
 
     @Test
@@ -102,22 +102,22 @@ public class DoubleMedianPivotTest {
         // 2 2 -2- 2 2 2 -2- 2 2 2
         int[] numbers = new int[]{2, 2, 2, 2, 2, 2, 2, 2, 2, 2};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 2 4 10 -10- 10 10 11 12 -12- 12 14 15 16
         numbers = new int[]{16, 15, 14, 12, 12, 12, 11, 10, 10, 10, 10, 4, 2};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(7, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(7, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 2 4 10 -10- 10 10 12 -12- 12 14 15 16
         numbers = new int[]{16, 15, 14, 12, 12, 12, 10, 10, 10, 10, 4, 2};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(6, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(6, 3, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 10 10 -10- 10 10 -10- 15 20
         numbers = new int[]{10, 10, 10, 15, 10, 20, 10, 10};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
     }
 
     /**
@@ -133,12 +133,12 @@ public class DoubleMedianPivotTest {
         // 5 5 5 5 5 -5- 6 6 6 6 6 -6- 6 6 55 55 55
         int[] numbers = new int[]{5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55, 6, 5, 6, 5, 6, 55};
         DualPivotFinder dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
 
         // 5 6 7 -44- 44 44 44 -44- 44 44 44
         numbers = new int[]{44, 44, 44, 5, 6, 44, 44, 7, 44, 44, 44};
         dualPivotFinder = DualPivotFinder.getMedianPivotFront(numbers.length);
-        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length));
+        assertDoubleMedians(0, 1, dualPivotFinder.findPivot(numbers, 0, numbers.length - 1));
     }
 
     private void assertDoubleMedians(int firstPivot, int secondPivot, int[] actualPivots) {


### PR DESCRIPTION
This reverts commit 3201f965a81e7b061d8a047888188ecb3c11ca1c.

Turns out the order of the pivots **is** defined for `DualPivotFinder.getMedianPivotFront()` and `DualPivotFinder.getMedianPivotDistributed()`