### PR TITLE
fix testValidAVLSame2

### DIFF
--- a/e09-avl-tree/src/tests/testValidAVL.java
+++ b/e09-avl-tree/src/tests/testValidAVL.java
@@ -42,7 +42,7 @@ public class testValidAVL {
 
         avlTree.setRoot(root);
 
-        validAVLTester(true, avlTree);
+        validAVLTester(false, avlTree);
     }
 
     @Test


### PR DESCRIPTION
testValidAVLSimple2() creates a tree with 3 nodes, with the value 3 as root, 2 as left child and 1 as right child and is therefore not a valid tree, because the right value is smaller than its parent. Wrongly, however, it is considered correct in the test
![image](https://user-images.githubusercontent.com/93255373/175396048-223d3338-7fc8-43c9-b92a-c284e3bf1c60.png)
-> not a valid tree because the right value must be equal or bigger?
